### PR TITLE
Refactor error handling to use `error` type and `tinystring`

### DIFF
--- a/add.go
+++ b/add.go
@@ -3,11 +3,12 @@ package indexdb
 import (
 	"syscall/js"
 
+	. "github.com/cdvelop/tinystring"
 	"github.com/cdvelop/unixid"
 )
 
 // run = RunBootData()
-func Add(h *MainHandler) (err string) {
+func Add(h *MainHandler) (err error) {
 
 	newDb := indexDB{
 		db_name:               "localdb",
@@ -23,13 +24,13 @@ func Add(h *MainHandler) (err string) {
 	h.DataBaseAdapter = &newDb
 
 	uid, err := unixid.NewUnixID(h)
-	if err != "" {
-		return err
+	if err != nil {
+		return Err("error creating new unixid", err)
 	}
 
 	newDb.UnixID = uid
 
-	return ""
+	return nil
 }
 
 func (indexDB) RunOnClientDB() bool { //true base de datos corre en el browser

--- a/index-check.go
+++ b/index-check.go
@@ -1,6 +1,10 @@
 package indexdb
 
-func (d *indexDB) fieldIndexOK(table, field_name string) (err string) {
+import (
+	. "github.com/cdvelop/tinystring"
+)
+
+func (d *indexDB) fieldIndexOK(table, field_name string) (err error) {
 
 	// Verificar si el índice existe en la tabla.
 	indexNames := d.store.Get("indexNames")
@@ -12,8 +16,8 @@ func (d *indexDB) fieldIndexOK(table, field_name string) (err string) {
 
 	// Verificar si el índice existe en la tabla.
 	if !indexSet[field_name] {
-		return "El índice: " + field_name + "no existe en la tabla:" + table
+		return Err("Index:", field_name, "does not exist in table:", table)
 	}
 
-	return ""
+	return nil
 }

--- a/method-clear.go
+++ b/method-clear.go
@@ -1,22 +1,26 @@
 package indexdb
 
-func (d *indexDB) ClearAllTableDataInDB(tables ...string) (err string) {
-	const e = "ClearAllTableDataInDB error "
+import (
+	. "github.com/cdvelop/tinystring"
+)
+
+func (d *indexDB) ClearAllTableDataInDB(tables ...string) (err error) {
+	const e = "ClearAllTableDataInDB error"
 	for _, table_name := range tables {
 
 		d.err = d.prepareStore("clear", table_name)
-		if d.err != "" {
-			return e + d.err
+		if d.err != nil {
+			return Errf("%s %v", e, d.err)
 		}
 
 		// elimina cada elemento en el almacén de objetos
 		result := d.store.Call("clear")
 
 		if result.IsNull() {
-			return e + "al borrar la data de la tabla: " + table_name
+			return Errf("%s error clearing data from table: %s", e, table_name)
 		}
 
 	}
 
-	return ""
+	return nil
 }

--- a/method-delete.go
+++ b/method-delete.go
@@ -1,16 +1,19 @@
 package indexdb
 
-func (d *indexDB) DeleteObjectsInDB(table_name string, on_server_too bool, all_data ...map[string]string) (err string) {
+import (
+	. "github.com/cdvelop/tinystring"
+)
 
-	const e = "DeleteObjectsInDB "
+func (d *indexDB) DeleteObjectsInDB(table_name string, on_server_too bool, all_data ...map[string]string) (err error) {
+
+	const e = "DeleteObjectsInDB"
 
 	if on_server_too {
 		d.BackupOneObjectType("delete", table_name, all_data)
 	}
 
-	d.err = d.prepareStore("delete", table_name)
-	if d.err != "" {
-		return e + d.err
+	if d.err = d.prepareStore("delete", table_name); d.err != nil {
+		return Errf("%s %v", e, d.err)
 	}
 
 	for _, data := range all_data {
@@ -19,14 +22,14 @@ func (d *indexDB) DeleteObjectsInDB(table_name string, on_server_too bool, all_d
 			d.result = d.store.Call("delete", id)
 
 			if d.result.IsNull() {
-				return e + "al eliminar en la tabla: " + table_name
+				return Errf("%s error when deleting in table: %s", e, table_name)
 			}
 
 		} else {
-			return e + "id no encontrado tabla: " + table_name
+			return Errf("%s id not found in table: %s", e, table_name)
 		}
 
 	}
 
-	return
+	return nil
 }

--- a/method-read.go
+++ b/method-read.go
@@ -3,10 +3,10 @@ package indexdb
 import (
 	"syscall/js"
 
-	"github.com/cdvelop/tinystring"
+	. "github.com/cdvelop/tinystring"
 )
 
-func (d *indexDB) ReadAsyncDataDB(p *ReadParams, callback func(r *ReadResults, err string)) {
+func (d *indexDB) ReadAsyncDataDB(p *ReadParams, callback func(r *ReadResults, err error)) {
 
 	var result = &ReadResults{
 		ResultsString: []map[string]string{},
@@ -14,7 +14,7 @@ func (d *indexDB) ReadAsyncDataDB(p *ReadParams, callback func(r *ReadResults, e
 	}
 
 	d.err = d.readPrepareCursor(p)
-	if d.err != "" {
+	if d.err != nil {
 		callback(nil, d.err)
 		return
 	}
@@ -27,7 +27,7 @@ func (d *indexDB) ReadAsyncDataDB(p *ReadParams, callback func(r *ReadResults, e
 
 			for _, wheres := range p.WHERE {
 				for key, search := range wheres {
-					if !tinystring.Contains(data.Get(key).String(), search) {
+					if !Contains(data.Get(key).String(), search) {
 						item.Call("continue")
 						return nil
 					}
@@ -76,13 +76,13 @@ func (d *indexDB) ReadAsyncDataDB(p *ReadParams, callback func(r *ReadResults, e
 			item.Call("continue")
 		} else {
 			// d.Log("Fin de los datos.")
-			callback(result, "")
+			callback(result, nil)
 		}
 		return nil
 	}))
 
 }
 
-func (d *indexDB) ReadSyncDataDB(p *ReadParams, data ...map[string]string) (result []map[string]string, err string) {
-	return nil, "error ReadSyncDataDB no implementado en indexDB"
+func (d *indexDB) ReadSyncDataDB(p *ReadParams, data ...map[string]string) (result []map[string]string, err error) {
+	return nil, Err("error ReadSyncDataDB not implemented in indexDB")
 }

--- a/method-update.go
+++ b/method-update.go
@@ -1,16 +1,19 @@
 package indexdb
 
-func (d *indexDB) UpdateObjectsInDB(table_name string, on_server_too bool, all_data ...map[string]string) (err string) {
+import (
+	. "github.com/cdvelop/tinystring"
+)
 
-	const e = "UpdateObjectsInDB "
+func (d *indexDB) UpdateObjectsInDB(table_name string, on_server_too bool, all_data ...map[string]string) (err error) {
+
+	const e = "UpdateObjectsInDB"
 
 	if on_server_too {
 		d.BackupOneObjectType("update", table_name, all_data)
 	}
 	// Obtener el almacén
-	d.err = d.prepareStore("update", table_name)
-	if d.err != "" {
-		return e + d.err
+	if d.err = d.prepareStore("update", table_name); d.err != nil {
+		return Errf("%s %v", e, d.err)
 	}
 
 	d.prepareDataIN(all_data, true)
@@ -21,16 +24,16 @@ func (d *indexDB) UpdateObjectsInDB(table_name string, on_server_too bool, all_d
 		// Obtener el ID del objeto
 		id, ok := obj[PREFIX_ID_NAME+table_name].(string)
 		if !ok || id == "" {
-			return e + "objeto invalido sin ID para actualizar "
+			return Errf("%s invalid object without ID to update", e)
 		}
 
 		// Guardar los cambios
 		d.result = d.store.Call("put", obj)
 		if d.result.IsNull() {
-			return e + "al actualizar objeto " + id + " en la db"
+			return Errf("%s when updating object %s in the db", e, id)
 		}
 
 	}
 
-	return ""
+	return nil
 }

--- a/model.go
+++ b/model.go
@@ -20,6 +20,7 @@ type ReadParams struct {
 type ReadResults struct {
 	ResultsString []map[string]string
 	ResultsAny    []map[string]any
+	Error         error
 }
 
 type MainHandler struct {
@@ -66,11 +67,11 @@ type DataBaseAdapter interface {
 	RunOnClientDB() bool
 	Lock()
 	Unlock()
-	CreateObjectsInDB(table_name string, on_server_too bool, items any) (err string)
-	ReadAsyncDataDB(p *ReadParams, callback func(r *ReadResults, err string))
-	ReadSyncDataDB(p *ReadParams, data ...map[string]string) (result []map[string]string, err string)
-	DeleteObjectsInDB(table_name string, on_server_too bool, all_data ...map[string]string) (err string)
-	UpdateObjectsInDB(table_name string, on_server_too bool, all_data ...map[string]string) (err string)
+	CreateObjectsInDB(table_name string, on_server_too bool, items any) (err error)
+	ReadAsyncDataDB(p *ReadParams, callback func(r *ReadResults, err error))
+	ReadSyncDataDB(p *ReadParams, data ...map[string]string) (result []map[string]string, err error)
+	DeleteObjectsInDB(table_name string, on_server_too bool, all_data ...map[string]string) (err error)
+	UpdateObjectsInDB(table_name string, on_server_too bool, all_data ...map[string]string) (err error)
 }
 
 type TimeAdapter interface {
@@ -102,5 +103,5 @@ type indexDB struct {
 	store       js.Value
 	cursor      js.Value
 	result      js.Value
-	err         string
+	err         error
 }

--- a/read-cursor.go
+++ b/read-cursor.go
@@ -2,13 +2,15 @@ package indexdb
 
 import (
 	"syscall/js"
+
+	. "github.com/cdvelop/tinystring"
 )
 
-func (d *indexDB) readPrepareCursor(r *ReadParams) (err string) {
-	const e = "readPrepareCursor error "
+func (d *indexDB) readPrepareCursor(r *ReadParams) (err error) {
+	const e = "readPrepareCursor error"
 
-	if d.err = d.checkTableStatus("read", r.FROM_TABLE); d.err != "" {
-		return e + d.err
+	if d.err = d.checkTableStatus("read", r.FROM_TABLE); d.err != nil {
+		return Errf("%s %v", e, d.err)
 	}
 
 	sort_order := "next"
@@ -17,9 +19,8 @@ func (d *indexDB) readPrepareCursor(r *ReadParams) (err string) {
 	}
 
 	// Obtener el almacén
-	d.err = d.prepareStore("read", r.FROM_TABLE)
-	if d.err != "" {
-		return e + d.err
+	if d.err = d.prepareStore("read", r.FROM_TABLE); d.err != nil {
+		return Errf("%s %v", e, d.err)
 	}
 
 	switch {
@@ -28,8 +29,8 @@ func (d *indexDB) readPrepareCursor(r *ReadParams) (err string) {
 
 		field_name := PREFIX_ID_NAME + r.FROM_TABLE
 
-		if d.err = d.fieldIndexOK(r.FROM_TABLE, field_name); d.err != "" {
-			return e + d.err
+		if d.err = d.fieldIndexOK(r.FROM_TABLE, field_name); d.err != nil {
+			return Errf("%s %v", e, d.err)
 		}
 
 		rangeObj := js.Global().Get("IDBKeyRange").Call("only", r.ID)
@@ -38,8 +39,8 @@ func (d *indexDB) readPrepareCursor(r *ReadParams) (err string) {
 
 	case r.ORDER_BY != "":
 
-		if d.err = d.fieldIndexOK(r.FROM_TABLE, r.ORDER_BY); d.err != "" {
-			return e + d.err
+		if d.err = d.fieldIndexOK(r.FROM_TABLE, r.ORDER_BY); d.err != nil {
+			return Errf("%s %v", e, d.err)
 		}
 
 		index := d.store.Call("index", r.ORDER_BY)
@@ -50,5 +51,5 @@ func (d *indexDB) readPrepareCursor(r *ReadParams) (err string) {
 		d.cursor = d.store.Call("openCursor")
 	}
 
-	return
+	return nil
 }

--- a/store.go
+++ b/store.go
@@ -1,9 +1,13 @@
 package indexdb
 
-// action create,read, delete, update
-func (d *indexDB) prepareStore(action, table_name string) (err string) {
+import (
+	. "github.com/cdvelop/tinystring"
+)
 
-	if d.err = d.checkTableStatus(action, table_name); d.err != "" {
+// action create,read, delete, update
+func (d *indexDB) prepareStore(action, table_name string) (err error) {
+
+	if d.err = d.checkTableStatus(action, table_name); d.err != nil {
 		return d.err
 	}
 
@@ -19,8 +23,8 @@ func (d *indexDB) prepareStore(action, table_name string) (err string) {
 	d.store = d.transaction.Call("objectStore", table_name)
 
 	if !d.store.Truthy() {
-		return "error no se logro abrir el almacén: " + table_name + " db para la acción " + action
+		return Err("error could not open store:", table_name, "for action", action)
 	}
 
-	return ""
+	return nil
 }

--- a/table.go
+++ b/table.go
@@ -1,5 +1,9 @@
 package indexdb
 
+import (
+	. "github.com/cdvelop/tinystring"
+)
+
 func (d *indexDB) createTable(o *Object) {
 
 	if !o.NoAddObjectInDB {
@@ -21,17 +25,17 @@ func (d *indexDB) createTable(o *Object) {
 	}
 }
 
-func (d indexDB) checkTableStatus(operation, table_name string) (err string) {
+func (d indexDB) checkTableStatus(operation, table_name string) (err error) {
 
 	if !d.db.Truthy() {
-		return "error " + operation + " variable db no definida en index db " + table_name
+		return Err(operation, "variable db not defined in index db", table_name)
 	}
 
 	if !d.TableExist(table_name) {
-		return "error acción: " + operation + ". tabla " + table_name + " no existe en indexdb"
+		return Err("error action:", operation, ". table", table_name, "does not exist in indexdb")
 	}
 
-	return ""
+	return nil
 }
 
 func (d indexDB) TableExist(table_name string) bool {

--- a/x-read-promises.go
+++ b/x-read-promises.go
@@ -2,19 +2,20 @@ package indexdb
 
 import (
 	"syscall/js"
+
+	. "github.com/cdvelop/tinystring"
 )
 
-func (d *indexDB) ReadStringDataInDBold(r *ReadParams) (out []map[string]string, err string) {
-	const e = "ReadStringDataInDB error "
+func (d *indexDB) ReadStringDataInDBold(r *ReadParams) (out []map[string]string, err error) {
+	const e = "ReadStringDataInDB error"
 
 	d.Log("info COMIENZO LECTURA")
 
 	// d.readParams = r
 
 	// Abre un cursor para iterar sobre los objetos en el almacén
-	d.err = d.readPrepareCursor(r)
-	if d.err != "" {
-		return nil, e + d.err
+	if d.err = d.readPrepareCursor(r); d.err != nil {
+		return nil, Errf("%s %v", e, d.err)
 	}
 
 	// Define las funciones resolve y reject
@@ -44,7 +45,7 @@ func (d *indexDB) ReadStringDataInDBold(r *ReadParams) (out []map[string]string,
 
 	d.Log("info FIN LECTURA")
 
-	return
+	return nil, nil
 }
 
 func (d *indexDB) onSuccess(resolve, reject js.Func) js.Func {
@@ -88,7 +89,7 @@ func (d *indexDB) onSuccess(resolve, reject js.Func) js.Func {
 				// Maneja errores
 				d.cursor.Set("onerror", js.FuncOf(func(e js.Value, p []js.Value) interface{} {
 					// Aquí podrías rechazar la promesa con el error
-					reject.Invoke("Error en el cursor")
+					reject.Invoke("Error in cursor")
 					return nil
 				}))
 


### PR DESCRIPTION
This commit refactors the entire codebase to change the error handling mechanism.

- Replaced functions returning `(err string)` with functions returning `(err error)`.
- Used `tinystring.Err` and `tinystring.Errf` to create error messages in English.
- Translated all error messages from Spanish to English.
- Updated the `indexDB` struct, `DataBaseAdapter` interface, and `ReadResults` struct to use the `error` type, ensuring type consistency.
- Fixed a compilation error in `add.go` that was discovered during testing.